### PR TITLE
Added successful message writes with offset

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -913,6 +913,7 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 			}
 			for i, msg := range pSet.msgs {
 				msg.Offset = block.Offset + int64(i)
+				Logger.Printf("successfully wrote message onto topic %v on partition %d with offset %d", msg.Topic, msg.Partition, msg.Offset)
 			}
 			bp.parent.returnSuccesses(pSet.msgs)
 		// Duplicate


### PR DESCRIPTION
I wanted to log as close as I could to the write. There is a channel of successful messages that I should be able to use instead, but I 1. Couldn't get it to work and 2. is further away from the send.